### PR TITLE
Disabling the pyliny precommit hook.

### DIFF
--- a/scripts/hooks/py-pre-commit
+++ b/scripts/hooks/py-pre-commit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-make -C python-api lint pep8
+#make -C python-api lint pep8


### PR DESCRIPTION
The precommit hook isn't smart enough to understand it should only run on
commits which are changing python files.
