### PR TITLE
Set video format support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ imgurbash.sh.*
 /gst-plugins-good
 /gst-plugins-bad
 /gst-plugins-base
+/gst-switch.sublime-*
 /libvpx
 /html
 /htmlcov

--- a/run-demo.sh
+++ b/run-demo.sh
@@ -4,7 +4,7 @@
 
 killall gst-switch-srv || true
 sleep 2
-./tools/gst-switch-srv -r &
+./tools/gst-switch-srv -f debug -r &
 sleep 2
 ./tools/gst-switch-ui &
 sleep 2

--- a/tests/unit/test_gstswitchopts.c
+++ b/tests/unit/test_gstswitchopts.c
@@ -4,31 +4,32 @@
 static void
 test_strings_good (void)
 {
-  g_assert_cmpint (parse_format ("debug"), ==, 0);
-  g_assert_cmpint (parse_format ("pal"), ==, 0);
-  g_assert_cmpint (parse_format ("720p60"), ==, 0);
-  g_assert_cmpint (parse_format ("1024x768@60"), ==, 0);
-  g_assert_cmpint (parse_format ("VGA@60"), ==, 0);
-  g_assert_cmpint (parse_format ("4k@60"), ==, 0);
+  g_assert_cmpint (parse_format ("debug", NULL, NULL), ==, 0);
+  g_assert_cmpint (parse_format ("pal", NULL, NULL), ==, 0);
+  g_assert_cmpint (parse_format ("720p60", NULL, NULL), ==, 0);
+  g_assert_cmpint (parse_format ("1024x768@60", NULL, NULL), ==, 0);
+  g_assert_cmpint (parse_format ("VGA@60", NULL, NULL), ==, 0);
+  g_assert_cmpint (parse_format ("4k@60", NULL, NULL), ==, 0);
   g_assert_cmpint (parse_format
-      ("video/x-raw,height=400,width=500,framerate=25/1"), ==, 0);
+      ("video/x-raw,height=400,width=500,framerate=25/1", NULL, NULL), ==, 0);
 }
 
 static void
 test_strings_bad (void)
 {
   g_assert_cmpint (parse_format
-      ("video/x-raw,height=[400,800],width=500,framerate=25/1"), ==, -1);
-  g_assert_cmpint (parse_format ("720p@75"), ==, -1);
-  g_assert_cmpint (parse_format ("bad-format-string"), ==, -1);
+      ("video/x-raw,height=[400,800],width=500,framerate=25/1", NULL, NULL), ==,
+      -1);
+  g_assert_cmpint (parse_format ("720p@75", NULL, NULL), ==, -1);
+  g_assert_cmpint (parse_format ("bad-format-string", NULL, NULL), ==, -1);
   g_assert_cmpint (parse_format
-      ("video/x-raw,height=10,width=500,framerate=25/1"), ==, -1);
+      ("video/x-raw,height=10,width=500,framerate=25/1", NULL, NULL), ==, -1);
   g_assert_cmpint (parse_format
-      ("video/x-raw,height=400,width=10,framerate=25/1"), ==, -1);
+      ("video/x-raw,height=400,width=10,framerate=25/1", NULL, NULL), ==, -1);
   g_assert_cmpint (parse_format
-      ("video/x-raw,height=400,width=10,framerate=1001/1"), ==, -1);
-// the following actually works but it shouldn't
-//  g_assert_cmpint (parse_format("pal@75"), ==, -1);
+      ("video/x-raw,height=400,width=10,framerate=1001/1", NULL, NULL), ==, -1);
+// @FIXME the following actually works but it shouldn't
+//  g_assert_cmpint (parse_format("pal@75", NULL, NULL), ==, -1);
 }
 
 int

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -23,7 +23,7 @@ endif
 
 gst_switch_srv_SOURCES = gstworker.c gstswitchserver.c gstcase.c \
   gstcomposite.c gstswitchcontroller.c gstrecorder.c \
-  gio/gsocketinputstream.c
+  gio/gsocketinputstream.c gstswitchopts.c
 gst_switch_srv_CFLAGS = $(GST_CFLAGS) $(GST_BASE_CFLAGS) $(GCOV_CFLAGS) \
   $(GST_PLUGINS_BASE_CFLAGS) $(AM_CFLAGS) -DLOG_PREFIX="\"gst-switch-srv\""
 gst_switch_srv_LDFLAGS = $(GCOV_LFLAGS) $(GST_LIBS) $(GST_BASE_LIBS) \

--- a/tools/gstcase.c
+++ b/tools/gstcase.c
@@ -505,42 +505,42 @@ gst_case_class_init (GstCaseClass * klass)
       g_param_spec_uint ("width", "Width",
           "Output width", 1,
           G_MAXINT,
-          GST_SWITCH_COMPOSITE_DEFAULT_WIDTH,
+          gst_composite_default_width (),
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (object_class, PROP_HEIGHT,
       g_param_spec_uint ("height", "Height",
           "Output height", 1,
           G_MAXINT,
-          GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT,
+          gst_composite_default_height (),
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (object_class, PROP_A_WIDTH,
       g_param_spec_uint ("awidth", "A Width",
           "Channel A width", 1,
           G_MAXINT,
-          GST_SWITCH_COMPOSITE_DEFAULT_WIDTH,
+          gst_composite_default_width (),
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (object_class, PROP_A_HEIGHT,
       g_param_spec_uint ("aheight", "A Height",
           "Channel A height", 1,
           G_MAXINT,
-          GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT,
+          gst_composite_default_height (),
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (object_class, PROP_B_WIDTH,
       g_param_spec_uint ("bwidth", "B Width",
           "Channel B width", 1,
           G_MAXINT,
-          GST_SWITCH_COMPOSITE_DEFAULT_WIDTH,
+          gst_composite_default_width (),
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (object_class, PROP_B_HEIGHT,
       g_param_spec_uint ("bheight", "B Height",
           "Channel B height", 1,
           G_MAXINT,
-          GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT,
+          gst_composite_default_height (),
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   worker_class->prepare = (GstWorkerPrepareFunc) gst_case_prepare;

--- a/tools/gstcomposite.h
+++ b/tools/gstcomposite.h
@@ -36,17 +36,17 @@
 #define GST_IS_COMPOSITE(object) (G_TYPE_CHECK_INSTANCE_TYPE ((object), GST_TYPE_COMPOSITE))
 #define GST_IS_COMPOSITE_CLASS(class) (G_TYPE_CHECK_CLASS_TYPE ((class), GST_TYPE_COMPOSITE))
 
-#if ENABLE_LOW_RESOLUTION
-#define GST_SWITCH_COMPOSITE_DEFAULT_WIDTH	LOW_RES_W       /* 640 */
-#define GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT	LOW_RES_H       /* 480 */
-#define GST_SWITCH_COMPOSITE_MIN_PIP_W		13
-#define GST_SWITCH_COMPOSITE_MIN_PIP_H		7
-#else
-#define GST_SWITCH_COMPOSITE_DEFAULT_WIDTH	1280
-#define GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT	720
-#define GST_SWITCH_COMPOSITE_MIN_PIP_W		320
-#define GST_SWITCH_COMPOSITE_MIN_PIP_H		240
-#endif
+//#if ENABLE_LOW_RESOLUTION
+//#define GST_SWITCH_COMPOSITE_DEFAULT_WIDTH	LOW_RES_W       /* 640 */
+//#define GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT	LOW_RES_H       /* 480 */
+//#define GST_SWITCH_COMPOSITE_MIN_PIP_W		13
+//#define GST_SWITCH_COMPOSITE_MIN_PIP_H		7
+//#else
+//#define GST_SWITCH_COMPOSITE_DEFAULT_WIDTH	1280
+//#define GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT	720
+//#define GST_SWITCH_COMPOSITE_MIN_PIP_W		320
+//#define GST_SWITCH_COMPOSITE_MIN_PIP_H		240
+//#endif
 
 #define GST_SWITCH_FACEDETECT_FRAME_WIDTH	150
 #define GST_SWITCH_FACEDETECT_FRAME_HEIGHT	100
@@ -154,5 +154,10 @@ struct _GstCompositeClass
 GType gst_composite_get_type (void);
 gboolean gst_composite_adjust_pip (GstComposite * composite,
     gint x, gint y, gint w, gint h);
+gint gst_composite_default_width ();
+gint gst_composite_default_height ();
+gint gst_check_composite_min_pip_width (gint pip_w);
+gint gst_check_composite_min_pip_height (gint pip_h);
+
 
 #endif //__GST_COMPOSITE_H__

--- a/tools/gstrecorder.c
+++ b/tools/gstrecorder.c
@@ -279,7 +279,8 @@ gst_recorder_new_filename (const gchar * filename)
 static GString *
 gst_recorder_get_pipeline_string (GstRecorder * rec)
 {
-  const gchar *filename = gst_recorder_new_filename (opts.record_filename);
+  const gchar *filename =
+      gst_recorder_new_filename (gst_switch_server_get_record_filename ());
   GString *desc;
 
   //INFO ("Recording to %s and port %d", filename, rec->sink_port);
@@ -287,11 +288,9 @@ gst_recorder_get_pipeline_string (GstRecorder * rec)
   desc = g_string_new ("");
 
   // Encode the video with lossless jpeg
-  g_string_append_printf (
-      desc,
+  g_string_append_printf (desc,
       "intervideosrc name=source_video channel=composite_video ");
-  g_string_append_printf (
-      desc,
+  g_string_append_printf (desc,
       "! video/x-raw,width=%d,height=%d ", rec->width, rec->height);
   g_string_append_printf (desc, "! queue2 ");
   g_string_append_printf (desc, "! jpegenc quality=100 ");
@@ -299,29 +298,24 @@ gst_recorder_get_pipeline_string (GstRecorder * rec)
   g_string_append_printf (desc, "\n");
 
   // Don't encode the audio
-  g_string_append_printf (
-      desc,
+  g_string_append_printf (desc,
       "interaudiosrc name=source_audio channel=composite_audio ");
   g_string_append_printf (desc, "! queue2 ");
   g_string_append_printf (desc, "! mux. ");
   g_string_append_printf (desc, "\n");
 
   // Output in streamable mkv format
-  g_string_append_printf (
-      desc,
+  g_string_append_printf (desc,
       "matroskamux name=mux"
       " streamable=true "
-      " writing-app='gst-switch' "
-      " min-index-interval=1000000 "
-      );
+      " writing-app='gst-switch' " " min-index-interval=1000000 ");
   g_string_append_printf (desc, "! tee name=result ");
   g_string_append_printf (desc, "\n");
 
   if (filename) {
     g_string_append_printf (desc, "result. ");
     g_string_append_printf (desc, "! queue2 ");
-    g_string_append_printf (
-        desc,
+    g_string_append_printf (desc,
         "! filesink name=disk_sink sync=false location=\"%s\" ", filename);
     g_free ((gpointer) filename);
     g_string_append_printf (desc, "\n");
@@ -330,12 +324,10 @@ gst_recorder_get_pipeline_string (GstRecorder * rec)
   g_string_append_printf (desc, "result. ");
   g_string_append_printf (desc, "! queue2 ");
   g_string_append_printf (desc, "! gdppay ");
-  g_string_append_printf (
-      desc,
-      "! tcpserversink name=tcp_sink sync=false port=%d ",
-      rec->sink_port);
+  g_string_append_printf (desc,
+      "! tcpserversink name=tcp_sink sync=false port=%d ", rec->sink_port);
 
-  INFO("Recording pipeline\n----\n%s\n---", desc->str);
+  INFO ("Recording pipeline\n----\n%s\n---", desc->str);
 
   return desc;
 }
@@ -442,7 +434,7 @@ gst_recorder_class_init (GstRecorderClass * klass)
       g_param_spec_uint ("width", "Input Width",
           "Input video frame width",
           1, G_MAXINT,
-          GST_SWITCH_COMPOSITE_DEFAULT_WIDTH,
+          gst_composite_default_width (),
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (object_class, PROP_HEIGHT,
@@ -450,7 +442,7 @@ gst_recorder_class_init (GstRecorderClass * klass)
           "Input Height",
           "Input video frame height",
           1, G_MAXINT,
-          GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT,
+          gst_composite_default_height (),
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   worker_class->prepare = (GstWorkerPrepareFunc) gst_recorder_prepare;

--- a/tools/gstswitchcapture.c
+++ b/tools/gstswitchcapture.c
@@ -35,6 +35,15 @@
 #include <stdlib.h>
 #include "../logutils.h"
 
+/* @FIXME: moved from gstcomposite which now determines these dynamically */
+#if ENABLE_LOW_RESOLUTION
+#define GST_SWITCH_COMPOSITE_DEFAULT_WIDTH  LOW_RES_W   /* 640 */
+#define GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT LOW_RES_H   /* 480 */
+#else
+#define GST_SWITCH_COMPOSITE_DEFAULT_WIDTH  1280
+#define GST_SWITCH_COMPOSITE_DEFAULT_HEIGHT 720
+#endif
+
 #define GST_TYPE_SWITCH_CAPTURE_WORKER (gst_switch_capture_worker_get_type ())
 #define GST_SWITCH_CAPTURE_WORKER(object) (G_TYPE_CHECK_INSTANCE_CAST ((object), GST_TYPE_SWITCH_CAPTURE_WORKER, GstSwitchCaptureWorker))
 #define GST_SWITCH_CAPTURE_WORKER_CLASS(class) (G_TYPE_CHECK_CLASS_CAST ((class), GST_TYPE_SWITCH_CAPTURE_WORKER, GstSwitchCaptureWorkerClass))

--- a/tools/gstswitchopts.c
+++ b/tools/gstswitchopts.c
@@ -101,6 +101,7 @@ parse_short_format (const gchar * format, GstCaps * caps)
   gdouble format_rate = 0;
   gint format_rate_num = 0;
   gint format_rate_den = 1;
+  int r;
 
   gsize format_len = strlen (format);
   gchar format_buf[TMP_BUF_SIZE];
@@ -137,9 +138,10 @@ parse_short_format (const gchar * format, GstCaps * caps)
 
 parse_short_format_found_alias:
 //printf("Current format string: '%s'\n", format_buf);
+  r = sscanf (format_buf, "%dx%d@%lf/%d", &format_width, &format_height,
+      &format_rate, &format_rate_den);
 
-  switch (sscanf (format_buf, "%dx%d@%lf/%d", &format_width, &format_height,
-          &format_rate, &format_rate_den)) {
+  switch (r) {
     case 4:                    // all 4 args consumed
       format_rate_num = gst_gdouble_to_guint64 (format_rate);
       // Check the double was really an int
@@ -152,7 +154,7 @@ parse_short_format_found_alias:
       // @TODO: this will ignore additional @rate specifiers which
       // may occur e.g. pal@75, should raise an error
       break;
-    default:                  // Wasn't able to parse the format format.
+    default:                   // Wasn't able to parse the format format.
       return FALSE;
   }
 
@@ -167,7 +169,7 @@ parse_short_format_found_alias:
 // Smallest resolution is 300x200 (required for PIP to work) and largest is
 // 8k (arbitrarily chosen).
 int
-parse_format (const gchar * format, GstCaps **caps, GError **error)
+parse_format (const gchar * format, GstCaps ** caps, GError ** error)
 {
   const gchar *error_msg = "Invalid video format specified";
   GstCaps *require_caps = gst_caps_from_string (requirements);
@@ -222,7 +224,7 @@ parse_format (const gchar * format, GstCaps **caps, GError **error)
   final_caps = gst_caps_intersect (require_caps, incoming_caps);
 //printf("   final-caps: %s\n", gst_caps_to_string(final_caps));
   int r = 0;
-  if (gst_caps_is_empty (final_caps) || gst_caps_is_fixed (final_caps)) {
+  if (gst_caps_is_empty (final_caps) || !gst_caps_is_fixed (final_caps)) {
 
   parse_format_error:
     r = -1;

--- a/tools/gstswitchserver.c
+++ b/tools/gstswitchserver.c
@@ -82,6 +82,8 @@ GstSwitchServerOpts opts = {
   GST_SWITCH_SERVER_DEFAULT_VIDEO_ACCEPTOR_PORT,
   GST_SWITCH_SERVER_DEFAULT_AUDIO_ACCEPTOR_PORT,
   GST_SWITCH_SERVER_DEFAULT_CONTROLLER_PORT,
+//FALSE,
+  NULL
 };
 
 gboolean verbose = FALSE;
@@ -136,6 +138,20 @@ gparse_record_filename (gchar * name, gchar * value, gpointer data,
   return TRUE;
 }
 
+
+extern int
+parse_format (const gchar * format, GstCaps **final_caps, GError **err);
+
+static gboolean
+gparse_video_format (gchar * name, gchar * value, gpointer data,
+    GError ** error)
+{
+  if (parse_format(value, &opts.video_caps, error) == -1)
+    return FALSE;
+  return TRUE;
+}
+
+
 static GOptionEntry entries[] = {
   {"verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,
       "Prompt more messages", NULL},
@@ -144,6 +160,9 @@ static GOptionEntry entries[] = {
   {"record", 'r', G_OPTION_FLAG_OPTIONAL_ARG, G_OPTION_ARG_CALLBACK,
         (gpointer) gparse_record_filename,
       "Enable recorder and record into the specified FILENAME"},
+  {"video-format", 'f', 0, G_OPTION_ARG_CALLBACK,
+        (gpointer) gparse_video_format,
+      "Specify the video format to use (shortcuts supported)"},
   {"video-input-port", 'p', 0, G_OPTION_ARG_INT, &opts.video_input_port,
       "Specify the video input listen port.", "NUM"},
   {"audio-input-port", 'a', 0, G_OPTION_ARG_INT, &opts.audio_input_port,
@@ -171,7 +190,7 @@ gst_switch_server_parse_args (int *argc, char **argv[])
     ERROR ("option parsing failed: %s", error->message);
     exit (1);
   } else if (*argc > 1) {
-    ERROR ("unknown option: %s", argv[1]);
+    ERROR ("unknown option: %s", (*argv)[1]);
     exit (1);
   }
 

--- a/tools/gstswitchserver.c
+++ b/tools/gstswitchserver.c
@@ -152,6 +152,8 @@ gparse_video_format (gchar * name, gchar * value, gpointer data,
   return TRUE;
 }
 
+static gboolean caps_dumped = FALSE;
+
 /* gst_switch_server_getcaps:
  * @return current video caps
  */
@@ -161,6 +163,12 @@ gst_switch_server_getcaps (void)
   if (opts.video_caps == NULL) {
     // use a sane default we know will parse correctly
     parse_format (opts.low_res ? "VGA" : "720p60", &opts.video_caps, NULL);
+  }
+  if (!caps_dumped) {
+    gchar *caps_str = gst_caps_to_string (opts.video_caps);
+    g_print ("caps: %s\n", caps_str);
+    g_free (caps_str);
+    caps_dumped = TRUE;
   }
   return opts.video_caps;
 }
@@ -207,6 +215,7 @@ gst_switch_server_parse_args (int *argc, char **argv[])
   GError *error = NULL;
   GOptionContext *context;
 
+  gst_init (NULL, NULL);
   context = g_option_context_new ("");
   g_option_context_add_main_entries (context, entries, "gst-switch");
   g_option_context_add_group (context, gst_init_get_option_group ());

--- a/tools/gstswitchserver.h
+++ b/tools/gstswitchserver.h
@@ -62,6 +62,9 @@ struct _GstSwitchServerOpts
   gint video_input_port;
   gint audio_input_port;
   gint control_port;
+//should really be in here
+//gboolean verbose;
+  GstCaps *video_caps;
 };
 
 /**

--- a/tools/gstswitchserver.h
+++ b/tools/gstswitchserver.h
@@ -64,6 +64,7 @@ struct _GstSwitchServerOpts
   gint control_port;
 //should really be in here
 //gboolean verbose;
+  gboolean low_res;
   GstCaps *video_caps;
 };
 
@@ -181,6 +182,9 @@ void gst_switch_server_mark_face (GstSwitchServer * srv,
 guint gst_switch_server_adjust_pip (GstSwitchServer * srv, gint dx, gint dy,
     gint dw, gint dh);
 gboolean gst_switch_server_new_record (GstSwitchServer * srv);
+
+GstCaps *gst_switch_server_getcaps (void);
+const gchar *gst_switch_server_get_record_filename (void);
 
 extern GstSwitchServerOpts opts;
 


### PR DESCRIPTION
Add support for selecting the video format to use at runtime.
Default resolution is 720p with the -l switch to select VGA resolution. -f overrides and allows a more complete specification.
