### PR TITLE
[DON'T MERGE] Removing debug info.

### DIFF
--- a/tools/gstaudiovisual.c
+++ b/tools/gstaudiovisual.c
@@ -369,11 +369,11 @@ gst_audio_visual_message (GstAudioVisual * visual, GstMessage * message)
            GST_TIME_ARGS (endtime), channels);
          */
       } else if (list_rms) {
-        INFO ("endtime: %" GST_TIME_FORMAT ", (%s) ",
-            GST_TIME_ARGS (endtime), G_VALUE_TYPE_NAME (list_rms));
+        //INFO ("endtime: %" GST_TIME_FORMAT ", (%s) ",
+        //    GST_TIME_ARGS (endtime), G_VALUE_TYPE_NAME (list_rms));
       } else {
-        INFO ("endtime: %" GST_TIME_FORMAT ", ->NULL<- ",
-            GST_TIME_ARGS (endtime));
+        //INFO ("endtime: %" GST_TIME_FORMAT ", ->NULL<- ",
+        //    GST_TIME_ARGS (endtime));
       }
     }
   }


### PR DESCRIPTION
Fixes the constant messages;
```
gst-switch-ui/gstaudiovisual.c:373:info: endtime: 0:00:00.266666666, (GValueArray) 
gst-switch-ui/gstaudiovisual.c:373:info: endtime: 0:00:00.366666666, (GValueArray) 
gst-switch-ui/gstaudiovisual.c:373:info: endtime: 0:00:00.466666666, (GValueArray) 
gst-switch-ui/gstaudiovisual.c:373:info: endtime: 0:00:00.566666666, (GValueArray) 
```