### PR TITLE
Handling fast connection close

### DIFF
--- a/tools/gstswitchcontroller.c
+++ b/tools/gstswitchcontroller.c
@@ -570,6 +570,10 @@ gst_switch_controller_call_client (GstSwitchController * controller,
       break;
   }
 
+  if (G_IS_DBUS_CONNECTION (connection) == 0) {
+    return NULL;
+  }
+
   value = g_dbus_connection_call_sync (connection, NULL,        /* bus_name */
       path, name, method_name, parameters, reply_type, G_DBUS_CALL_FLAGS_NONE, gst_switch_controller_dbus_timeout,      /* timeout_msec */
       NULL /* TODO: cancellable */ ,


### PR DESCRIPTION
@mithro The problem  if the API calls a method on the server the process is like - 
1. Server is running....
2. API makes connection
3. Server registers the API client (unknown role). This will involve the server querying the client over dbus for its `role`.
4. API queries server with some dbus method.
5. API closes connection.

Step 3 and Step (4 followed by 5) can happen in different orders since they occur on separate processes.
Since the registering processes in the server are callbacks, and the `connection` may die out before the server actually registers it.

