### PR TITLE
Fixed a bug in `gstswitch.VideoPipeline` that adds the time overlay twice

### DIFF
--- a/python-api/gstswitch/testsource.py
+++ b/python-api/gstswitch/testsource.py
@@ -97,11 +97,11 @@ class VideoPipeline(BasePipeline):
             vfilter.link(_timeoverlay)
             _timeoverlay.link(_clockoverlay)
             _clockoverlay.link(gdppay)
-        if timeoverlay:
+        elif timeoverlay:
             self.add(_timeoverlay)
             vfilter.link(_timeoverlay)
             _timeoverlay.link(gdppay)
-        if clockoverlay:
+        elif clockoverlay:
             self.add(_clockoverlay)
             vfilter.link(_clockoverlay)
             _clockoverlay.link(gdppay)


### PR DESCRIPTION
This fixes `unittests.test_testsource_unit.TestVideoPipeline.test_permuate_time_clock_4`