### PR TITLE
Dbus tcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Application Options:
   -r, --record=FILENAME             Enable recorder and record into the specified FILENAME
   -p, --video-input-port=NUM        Specify the video input listen port.
   -a, --audio-input-port=NUM        Specify the audio input listen port.
-  --control-port=NUM                Specify the control port.
+  -c, --controller-address=ADDRESS     Specify DBus-Address for remote control, defaults to tcp:host=0.0.0.0,port=5000.
 ```
 
 ### Video Input

--- a/python-api/gstswitch/connection.py
+++ b/python-api/gstswitch/connection.py
@@ -15,7 +15,7 @@ class Connection(object):
     """Class which makes all remote object class.
     Deals with lower level connection and remote method invoking
 
-    :default bus-address: unix:abstract=gstswitch
+    :default bus-address: tcp:host=127.0.0.1,port=5000
 
     :param: None
     """
@@ -23,7 +23,7 @@ class Connection(object):
 
     def __init__(
             self,
-            address="unix:abstract=gstswitch",
+            address="tcp:host=127.0.0.1,port=5000",
             bus_name='info.duzy.gst.switch.SwitchController',
             object_path="/info/duzy/gst/switch/SwitchController",
             default_interface=("info.duzy.gst.switch."

--- a/python-api/gstswitch/controller.py
+++ b/python-api/gstswitch/controller.py
@@ -28,7 +28,7 @@ class Controller(object):
 
     def __init__(
             self,
-            address="unix:abstract=gstswitch",
+            address="tcp:host=127.0.0.1,port=5000",
             bus_name='info.duzy.gst.switch.SwitchController',
             object_path="/info/duzy/gst/switch/SwitchController",
             default_interface="info.duzy.gst.switch.SwitchControllerInterface"

--- a/python-api/scripts/dbusConnect.py
+++ b/python-api/scripts/dbusConnect.py
@@ -13,7 +13,7 @@ def main():
     loop.run()
 
 if __name__=="__main__":
-    os.environ["DBUS_SESSION_BUS_ADDRESS"] = "unix:abstract=gstswitch"
+    os.environ["DBUS_SESSION_BUS_ADDRESS"] = "tcp:host=127.0.0.1,port=5000"
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
     main()
     

--- a/python-api/scripts/dbusConnect.sh
+++ b/python-api/scripts/dbusConnect.sh
@@ -1,10 +1,10 @@
 dbus-send \
- 	--address="unix:abstract=gstswitch" \
+ 	--address="tcp:host=127.0.0.1,port=5000" \
  	--print-reply=literal \
  	--dest="info.duzy.gst_switch.SwitchClientInterface" \
  	/info/duzy/gst_switch/SwitchController \
  	info.duzy.gst_switch.SwitchControllerInterface.get_compose_port
 
-gdbus introspect --address unix:abstract=gstswitch \
+gdbus introspect --address tcp:host=127.0.0.1,port=5000 \
 				 --dest info.duzy.gst.switch.SwitchUIInterface \
 				 --object-path /info/duzy/gst/switch/SwitchUI

--- a/python-api/scripts/dbusConnect2.py
+++ b/python-api/scripts/dbusConnect2.py
@@ -1,7 +1,7 @@
 from gi.repository import Gio, GLib
 from time import sleep
 
-address = "unix:abstract=gstswitch"
+address = "tcp:host=127.0.0.1,port=5000"
 name = None
 object_path = "/info/duzy/gst/switch/SwitchController"
 

--- a/python-api/scripts/dbusConnection3.py
+++ b/python-api/scripts/dbusConnection3.py
@@ -1,7 +1,7 @@
 from gi.repository import Gio, GLib
 from time import sleep
 
-address = "unix:abstract=gstswitch"
+address = "tcp:host=127.0.0.1,port=5000"
 name = None
 object_path = "/info/duzy/gst/switch/SwitchController"
 

--- a/python-api/tests/unittests/test_connection_unit.py
+++ b/python-api/tests/unittests/test_connection_unit.py
@@ -29,7 +29,7 @@ class TestAddress(object):
 
     def test_address_normal(self):
         """"Test if address is valid"""
-        address = ['unix:abstract=gstswitch', 'unix:temp=/tmp/abcd/xyz']
+        address = ['tcp:host=127.0.0.1,port=5000', 'unix:temp=/tmp/abcd/xyz']
         for addr in address:
             conn = Connection(address=addr)
             assert conn.address == addr

--- a/python-api/tests/unittests/test_controller_unit.py
+++ b/python-api/tests/unittests/test_controller_unit.py
@@ -30,7 +30,7 @@ class TestAddress(object):
 
     def test_address_normal(self):
         """Test if address is valid"""
-        address = ['unix:abstract=gstswitch', 'unix:temp=/tmp/abcd/xyz']
+        address = ['tcp:host=127.0.0.1,port=5000', 'unix:temp=/tmp/abcd/xyz']
         for addr in address:
             conn = Controller(address=addr)
             assert conn.address == addr

--- a/python-api/tests/unittests/test_server_unit.py
+++ b/python-api/tests/unittests/test_server_unit.py
@@ -29,7 +29,7 @@ class TestPath(object):
         serv._start_process = mock_method
         assert serv._run_process() == "/usr/gst-switch-srv \
 --video-input-port=3000 --audio-input-port=4000 \
---control-port=5000".split()
+--controller-address=tcp:host=0.0.0.0,port=5000".split()
 
     def test_path_provided_no_slash(self):
         """Test if a path is provided"""
@@ -41,7 +41,7 @@ class TestPath(object):
         serv._start_process = mock_method
         assert serv._run_process() == "/usr/gst-switch-srv \
 --video-input-port=3000 --audio-input-port=4000 \
---control-port=5000".split()
+--controller-address=tcp:host=0.0.0.0,port=5000".split()
 
     def test_path_empty(self, monkeypatch):
         """Test if null path is given"""
@@ -60,7 +60,7 @@ class TestPath(object):
             serv._start_process = mock_method
             assert serv._run_process() == "/usr/gst-switch-srv \
 --video-input-port=3000 --audio-input-port=4000 \
---control-port=5000".split()
+--controller-address=tcp:host=0.0.0.0,port=5000".split()
 
 
 class TestVideoPort(object):
@@ -119,32 +119,32 @@ class TestAudioPort(object):
                 Server(path=PATH, audio_port=audio_port)
 
 
-class TestControlPort(object):
+class TestControllerAddress(object):
 
-    """Test the control_port parameter"""
-    # Control Port Tests
+    """Test the controller_address parameter"""
+    # Control Address Tests
 
-    def test_invalid_control_port_null(self):
+    def test_invalid_controller_address_null(self):
         """Test when the control port is null"""
-        control_ports = [None, '', [], {}]
-        for control_port in control_ports:
+        controller_addresses = [None, '', [], {}]
+        for controller_address in controller_addresses:
             with pytest.raises(ValueError):
-                Server(path=PATH, control_port=control_port)
+                Server(path=PATH, controller_address=controller_address)
 
-    def test_invalid_control_port_type(self):
+    def test_invalid_controller_address_type(self):
         """Test when the control port is not a valid
         integral value"""
-        control_ports = [[1, 2, 3], {1: 2, 2: 3}]
-        for control_port in control_ports:
+        controller_addresses = [[1, 2, 3], {1: 2, 2: 3}]
+        for controller_address in controller_addresses:
             with pytest.raises(TypeError):
-                Server(path=PATH, control_port=control_port)
+                Server(path=PATH, controller_address=controller_address)
 
-    def test_invalid_control_port_range(self):
-        """Test when the control port is not in range"""
-        control_ports = [-99, -1, 1e6]
-        for control_port in control_ports:
+    def test_invalid_controller_address_range(self):
+        """Test when the control port does not contain a colon"""
+        controller_addresses = ['42', 'port=42', '127.0.0.1']
+        for controller_address in controller_addresses:
             with pytest.raises(ValueError):
-                Server(path=PATH, control_port=control_port)
+                Server(path=PATH, controller_address=controller_address)
 
 
 class TestRecordFile(object):
@@ -162,7 +162,7 @@ class TestRecordFile(object):
         serv._start_process = mock_method
         assert serv._run_process() == "/usr/gst-switch-srv \
 --video-input-port=3000 --audio-input-port=4000 \
---control-port=5000".split()
+--controller-address=tcp:host=0.0.0.0,port=5000".split()
 
     def test_record_file_true(self):
         """Test if record file is True"""
@@ -174,7 +174,7 @@ class TestRecordFile(object):
         serv._start_process = mock_method
         assert serv._run_process() == "/usr/gst-switch-srv \
 --video-input-port=3000 --audio-input-port=4000 \
---control-port=5000 -r".split()
+--controller-address=tcp:host=0.0.0.0,port=5000 -r".split()
 
     def test_record_file_valid(self):
         """Test if record file is valid"""
@@ -186,7 +186,7 @@ class TestRecordFile(object):
         serv._start_process = mock_method
         assert serv._run_process() == "/usr/gst-switch-srv \
 --video-input-port=3000 --audio-input-port=4000 \
---control-port=5000 --record=record.data".split()
+--controller-address=tcp:host=0.0.0.0,port=5000 --record=record.data".split()
 
     def test_record_file_valid_date(self):
         """Test if record file is valid"""
@@ -198,7 +198,7 @@ class TestRecordFile(object):
         serv._start_process = mock_method
         assert serv._run_process() == "/usr/gst-switch-srv \
 --video-input-port=3000 --audio-input-port=4000 \
---control-port=5000 \
+--controller-address=tcp:host=0.0.0.0,port=5000 \
 --record=record_%Y.data".split()
 
     def test_record_file_valid_space(self):
@@ -211,7 +211,8 @@ class TestRecordFile(object):
         serv._start_process = mock_method
         assert serv._run_process() == "/usr/gst-switch-srv \
 --video-input-port=3000 --audio-input-port=4000 \
---control-port=5000".split() + ["--record=record 1.data"]
+--controller-address=tcp:host=0.0.0.0,port=5000".split() + \
+            ["--record=record 1.data"]
 
     def test_record_file_invalid(self):
         """Test when the record_file is invalid"""

--- a/tests/test_switch_server.c
+++ b/tests/test_switch_server.c
@@ -1032,7 +1032,7 @@ testclient_run (gpointer data)
   client->mainloop = g_main_loop_new (NULL, TRUE);
 
   connect_ok =
-      gst_switch_client_connect (GST_SWITCH_CLIENT (client), CLIENT_ROLE_UI);
+      gst_switch_client_connect (GST_SWITCH_CLIENT (client), CLIENT_ROLE_UI, "tcp:host=127.0.0.1,port=5000");
   g_assert (connect_ok);
 
   client->compose_port0 =

--- a/tools/gst-switch-srv.sh
+++ b/tools/gst-switch-srv.sh
@@ -9,5 +9,5 @@
     --gst-debug="multiqueue:0" \
     --video-input-port="3000" \
     --audio-input-port="4000" \
-    --control-port="5000" \
+    --controller-address="tcp:host=0.0.0.0,port=5000" \
     --record="record.dat"

--- a/tools/gstswitchcapture.c
+++ b/tools/gstswitchcapture.c
@@ -49,6 +49,7 @@
 #define GST_SWITCH_CAPTURE_WORKER_CLASS(class) (G_TYPE_CHECK_CLASS_CAST ((class), GST_TYPE_SWITCH_CAPTURE_WORKER, GstSwitchCaptureWorkerClass))
 #define GST_IS_SWITCH_CAPTURE_WORKER(object) (G_TYPE_CHECK_INSTANCE_TYPE ((object), GST_TYPE_SWITCH_CAPTURE_WORKER))
 #define GST_IS_SWITCH_CAPTURE_WORKER_CLASS(class) (G_TYPE_CHECK_CLASS_TYPE ((class), GST_TYPE_SWITCH_CAPTURE_WORKER))
+#define GST_SWITCH_CAPTURE_DEFAULT_ADDRESS "tcp:host=127.0.0.1,port=5000"
 
 /**
  * @class GstSwitchCaptureWorker
@@ -80,6 +81,7 @@ G_DEFINE_TYPE (GstSwitchCaptureWorker, gst_switch_capture_worker,
 gboolean verbose = FALSE;
 const char *device = "/dev/ttyUSB0";
 const char *protocol = "visca";
+const char *srv_address = GST_SWITCH_CAPTURE_DEFAULT_ADDRESS;
 const char **srcsegments = NULL;
 int srcsegmentc = 0;
 
@@ -89,6 +91,8 @@ static GOptionEntry options[] = {
       "PTZ camera control device", "DEVICE"},
   {"protocol", 'p', 0, G_OPTION_ARG_STRING, &protocol,
       "PTZ camera control protocol", "NAME"},
+  {"address", 'a', 0, G_OPTION_ARG_STRING, &srv_address,
+      "Server Control-Adress, defaults to " GST_SWITCH_CAPTURE_DEFAULT_ADDRESS, NULL},
   {NULL}
 };
 
@@ -228,7 +232,7 @@ static void
 gst_switch_capture_run (GstSwitchCapture * capture)
 {
   if (!gst_switch_client_connect (GST_SWITCH_CLIENT (capture),
-          CLIENT_ROLE_CAPTURE)) {
+          CLIENT_ROLE_CAPTURE, srv_address)) {
     ERROR ("failed to connect to controller");
     return;
   }

--- a/tools/gstswitchclient.c
+++ b/tools/gstswitchclient.c
@@ -655,16 +655,14 @@ error_subscribe:
  */
 static void
 gst_switch_client_connect_controller (GstSwitchClient * client,
-    GstSwitchClientRole role)
+    GstSwitchClientRole role, const gchar *address)
 {
   GError *error = NULL;
   gboolean okay = FALSE;
 
   GST_SWITCH_CLIENT_LOCK_CONTROLLER (client);
 
-  client->controller = g_dbus_connection_new_for_address_sync (SWITCH_CONTROLLER_ADDRESS, G_DBUS_SERVER_FLAGS_RUN_IN_THREAD | G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT, NULL,      /* GDBusAuthObserver */
-      NULL,                     /* GCancellable */
-      &error);
+  client->controller = g_dbus_connection_new_for_address_sync (address, G_DBUS_SERVER_FLAGS_RUN_IN_THREAD | G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT, /* GDBusAuthObserver */NULL, /* GCancellable */NULL, &error);
 
   if (client->controller == NULL)
     goto error_new_connection;
@@ -727,14 +725,14 @@ gst_switch_client_is_connected (GstSwitchClient * client)
  *
  */
 gboolean
-gst_switch_client_connect (GstSwitchClient * client, GstSwitchClientRole role)
+gst_switch_client_connect (GstSwitchClient * client, GstSwitchClientRole role, const gchar *address)
 {
   if (gst_switch_client_is_connected (client)) {
     ERROR ("already connected");
     return FALSE;
   }
 
-  gst_switch_client_connect_controller (client, role);
+  gst_switch_client_connect_controller (client, role, address);
 
   return gst_switch_client_is_connected (client);
 }

--- a/tools/gstswitchclient.h
+++ b/tools/gstswitchclient.h
@@ -112,7 +112,7 @@ struct _GstSwitchClientClass
 GType gst_switch_client_get_type (void);
 
 gboolean gst_switch_client_is_connected (GstSwitchClient * client);
-gboolean gst_switch_client_connect (GstSwitchClient * client, GstSwitchClientRole role);
+gboolean gst_switch_client_connect (GstSwitchClient * client, GstSwitchClientRole role, const gchar* address);
 gint gst_switch_client_get_compose_port (GstSwitchClient * client);
 gint gst_switch_client_get_encode_port (GstSwitchClient * client);
 gint gst_switch_client_get_audio_port (GstSwitchClient * client);

--- a/tools/gstswitchcontroller.c
+++ b/tools/gstswitchcontroller.c
@@ -477,8 +477,11 @@ gst_switch_controller_init (GstSwitchController * controller)
   flags |= G_DBUS_SERVER_FLAGS_AUTHENTICATION_ALLOW_ANONYMOUS;
 
   auth_observer = g_dbus_auth_observer_new ();
-  controller->bus_server = g_dbus_server_new_sync (SWITCH_CONTROLLER_ADDRESS, flags, guid, auth_observer, NULL, /* GCancellable */
-      &error);
+
+  gchar *address = g_strdup_printf(SWITCH_CONTROLLER_ADDRESS, opts.control_port);
+  controller->bus_server = g_dbus_server_new_sync (address, flags, guid, auth_observer, /* GCancellable */NULL, &error);
+  g_free(address);
+
   if (error != NULL) {
     g_error ("failed to register controller: %s", error->message);
   }

--- a/tools/gstswitchcontroller.c
+++ b/tools/gstswitchcontroller.c
@@ -478,9 +478,7 @@ gst_switch_controller_init (GstSwitchController * controller)
 
   auth_observer = g_dbus_auth_observer_new ();
 
-  gchar *address = g_strdup_printf(SWITCH_CONTROLLER_ADDRESS, opts.control_port);
-  controller->bus_server = g_dbus_server_new_sync (address, flags, guid, auth_observer, /* GCancellable */NULL, &error);
-  g_free(address);
+  controller->bus_server = g_dbus_server_new_sync (opts.controller_address, flags, guid, auth_observer, /* GCancellable */NULL, &error);
 
   if (error != NULL) {
     g_error ("failed to register controller: %s", error->message);

--- a/tools/gstswitchcontroller.h
+++ b/tools/gstswitchcontroller.h
@@ -38,7 +38,6 @@
 #define GST_IS_SWITCH_CONTROLLER(object) (G_TYPE_CHECK_INSTANCE_TYPE ((object), GST_TYPE_SWITCH_CONTROLLER))
 #define GST_IS_SWITCH_CONTROLLER_CLASS(class) (G_TYPE_CHECK_CLASS_TYPE ((class), GST_TYPE_SWITCH_CONTROLLER))
 
-#define SWITCH_CONTROLLER_ADDRESS	"tcp:host=0.0.0.0,port=%u"
 #define SWITCH_CONTROLLER_OBJECT_NAME	 "info.duzy.gst.switch.SwitchControllerInterface"
 #define SWITCH_CONTROLLER_OBJECT_PATH	"/info/duzy/gst/switch/SwitchController"
 #define SWITCH_UI_OBJECT_NAME		 "info.duzy.gst.switch.SwitchUIInterface"

--- a/tools/gstswitchcontroller.h
+++ b/tools/gstswitchcontroller.h
@@ -38,8 +38,7 @@
 #define GST_IS_SWITCH_CONTROLLER(object) (G_TYPE_CHECK_INSTANCE_TYPE ((object), GST_TYPE_SWITCH_CONTROLLER))
 #define GST_IS_SWITCH_CONTROLLER_CLASS(class) (G_TYPE_CHECK_CLASS_TYPE ((class), GST_TYPE_SWITCH_CONTROLLER))
 
-// tcp:host=server.example.org,port=77777
-#define SWITCH_CONTROLLER_ADDRESS	"unix:abstract=gstswitch"
+#define SWITCH_CONTROLLER_ADDRESS	"tcp:host=0.0.0.0,port=%u"
 #define SWITCH_CONTROLLER_OBJECT_NAME	 "info.duzy.gst.switch.SwitchControllerInterface"
 #define SWITCH_CONTROLLER_OBJECT_PATH	"/info/duzy/gst/switch/SwitchController"
 #define SWITCH_UI_OBJECT_NAME		 "info.duzy.gst.switch.SwitchUIInterface"

--- a/tools/gstswitchserver.c
+++ b/tools/gstswitchserver.c
@@ -48,7 +48,7 @@
 #define GST_SWITCH_SERVER_DEFAULT_HOST "0.0.0.0"
 #define GST_SWITCH_SERVER_DEFAULT_VIDEO_ACCEPTOR_PORT	3000
 #define GST_SWITCH_SERVER_DEFAULT_AUDIO_ACCEPTOR_PORT	4000
-#define GST_SWITCH_SERVER_DEFAULT_CONTROLLER_PORT	5000
+#define GST_SWITCH_SERVER_DEFAULT_CONTROLLER_ADDRESS	"tcp:host=0.0.0.0,port=5000"
 #define GST_SWITCH_SERVER_LISTEN_BACKLOG 8      /* client connection queue */
 
 #define GST_SWITCH_SERVER_HOST_SPEC "%q"
@@ -78,10 +78,10 @@
 G_DEFINE_TYPE (GstSwitchServer, gst_switch_server, G_TYPE_OBJECT);
 
 GstSwitchServerOpts opts = {
-  NULL, NULL, NULL,
+  NULL, NULL,
+  GST_SWITCH_SERVER_DEFAULT_CONTROLLER_ADDRESS,
   GST_SWITCH_SERVER_DEFAULT_VIDEO_ACCEPTOR_PORT,
   GST_SWITCH_SERVER_DEFAULT_AUDIO_ACCEPTOR_PORT,
-  GST_SWITCH_SERVER_DEFAULT_CONTROLLER_PORT,
 //FALSE,
   FALSE,
   NULL, NULL
@@ -228,8 +228,8 @@ static GOptionEntry entries[] = {
       "Specify the video input listen port.", "NUM"},
   {"audio-input-port", 'a', 0, G_OPTION_ARG_INT, &opts.audio_input_port,
       "Specify the audio input listen port.", "NUM"},
-  {"control-port", 'p', 0, G_OPTION_ARG_INT, &opts.control_port,
-      "Specify the control port.", "NUM"},
+  {"controller-address", 'c', 0, G_OPTION_ARG_STRING, &opts.controller_address,
+      "Specify DBus-Address for remote control, defaults to " GST_SWITCH_SERVER_DEFAULT_CONTROLLER_ADDRESS ".", "ADDRESS"},
   {NULL}
 };
 

--- a/tools/gstswitchserver.h
+++ b/tools/gstswitchserver.h
@@ -131,9 +131,6 @@ struct _GstSwitchServer
   gint audio_acceptor_port;
 
   GMutex controller_lock;
-  GThread *controller_thread;
-  GSocket *controller_socket;
-  gint controller_port;
   GstSwitchController *controller;
 
   GMutex alloc_port_lock;

--- a/tools/gstswitchserver.h
+++ b/tools/gstswitchserver.h
@@ -52,7 +52,6 @@ typedef struct _GstSwitchServerOpts GstSwitchServerOpts;
  *  @param controller_address the dbus address for the controller
  *  @param video_input_port the video input TCP port
  *  @param audio_input_port the audio input TCP port
- *  @param control_port (discarded)
  */
 struct _GstSwitchServerOpts
 {
@@ -61,7 +60,6 @@ struct _GstSwitchServerOpts
   gchar *controller_address;
   gint video_input_port;
   gint audio_input_port;
-  gint control_port;
 //should really be in here
 //gboolean verbose;
   gboolean low_res;

--- a/tools/gstswitchui.c
+++ b/tools/gstswitchui.c
@@ -36,6 +36,7 @@
 #include "gstaudiovisual.h"
 #include "gstcase.h"
 
+#define GST_SWITCH_UI_DEFAULT_ADDRESS "tcp:host=127.0.0.1,port=5000"
 #define GST_SWITCH_UI_LOCK_AUDIO(ui) (g_mutex_lock (&(ui)->audio_lock))
 #define GST_SWITCH_UI_UNLOCK_AUDIO(ui) (g_mutex_unlock (&(ui)->audio_lock))
 #define GST_SWITCH_UI_LOCK_COMPOSE(ui) (g_mutex_lock (&(ui)->compose_lock))
@@ -50,11 +51,14 @@
 G_DEFINE_TYPE (GstSwitchUI, gst_switch_ui, GST_TYPE_SWITCH_CLIENT);
 
 gboolean verbose;
+gchar *srv_address = GST_SWITCH_UI_DEFAULT_ADDRESS;
 
 static GOptionEntry entries[] = {
   {"verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose, "Be verbose", NULL},
   {"dbus-timeout", 'd', 0, G_OPTION_ARG_INT, &gst_switch_client_dbus_timeout,
       "DBus timeout in ms (default 5000)", NULL},
+  {"address", 'a', 0, G_OPTION_ARG_STRING, &srv_address,
+      "Server Control-Adress, defaults to " GST_SWITCH_UI_DEFAULT_ADDRESS, NULL},
   {NULL}
 };
 
@@ -465,7 +469,7 @@ gst_switch_ui_tick (GstSwitchUI * ui)
 static void
 gst_switch_ui_run (GstSwitchUI * ui)
 {
-  if (!gst_switch_client_connect (GST_SWITCH_CLIENT (ui), CLIENT_ROLE_UI)) {
+  if (!gst_switch_client_connect (GST_SWITCH_CLIENT (ui), CLIENT_ROLE_UI, srv_address)) {
     ERROR ("failed to connect to controller");
     return;
   }


### PR DESCRIPTION
Remove unused TCP-Server ans reuse the now free Port for a DBus-via-TCP Interface.
Add a Command-Line option to the Clients to make their DBus Address configurable.
Set an DBus-Connection-String on the Server, too, instead of just a Port.

fixes #175