### PR TITLE
Bind to all IP address (IPv4 and IPv6) by default.

### DIFF
--- a/tools/gstswitchserver.c
+++ b/tools/gstswitchserver.c
@@ -39,10 +39,10 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#define GST_SWITCH_SERVER_DEFAULT_HOST "0.0.0.0"
+#define GST_SWITCH_SERVER_DEFAULT_HOST "::"     /* All IPv4 *and* IPv6 addresses */
 #define GST_SWITCH_SERVER_DEFAULT_VIDEO_ACCEPTOR_PORT	3000
 #define GST_SWITCH_SERVER_DEFAULT_AUDIO_ACCEPTOR_PORT	4000
-#define GST_SWITCH_SERVER_DEFAULT_CONTROLLER_ADDRESS	"tcp:host=0.0.0.0,port=5000"
+#define GST_SWITCH_SERVER_DEFAULT_CONTROLLER_ADDRESS	"tcp:host=::,port=5000"
 #define GST_SWITCH_SERVER_LISTEN_BACKLOG 8      /* client connection queue */
 
 #define GST_SWITCH_SERVER_HOST_SPEC "%q"


### PR DESCRIPTION
If the address is 0.0.0.0, the server accepts TCP/IP connections on all server
host IPv4 interfaces.

If the address is ::, the server accepts TCP/IP connections on all server host
IPv4 and IPv6 interfaces. Use this address to permit both IPv4 and IPv6
connections on all server interfaces.

Fixes issue #202.