### PR TITLE
Change to directory rather than using -C so ${PWD} is correct.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,8 +9,8 @@ test:
 	make style unittests integration
 
 #	TODO: Use configure to detect Python versions currently installed
-	make PYTHONVERSION=2.7 -Cpython-api style unittests integration
-	make PYTHONVERSION=3.4 -Cpython-api style unittests integration
+	cd python-api; make PYTHONVERSION=2.7 style unittests integration
+	cd python-api; make PYTHONVERSION=3.4 style unittests integration
 
 demo: $(UI_TESTS)
 


### PR DESCRIPTION
${PWD} is used in python-api/Makefile to set the PYTHONPATH. When using -C the value of PWD remains the top level directory rather than the python-api directory leading to import-errors when running pylint.

```
python2.7 /usr/local/bin/pylint --rcfile=.pylintrc_unittests tests/unittests/*
************* Module unittests.test_connection_unit
I:189, 0: Locally disabling unpacking-non-sequence (W0633) (locally-disabled)
F:  6, 0: Unable to import 'gstswitch.connection' (import-error)
F:  7, 0: Unable to import 'gstswitch.exception' (import-error)
************* Module unittests.test_controller_unit
F:  6, 0: Unable to import 'gstswitch.controller' (import-error)
F:  7, 0: Unable to import 'gstswitch.exception' (import-error)
F: 10, 0: Unable to import 'gstswitch.connection' (import-error)
************* Module unittests.test_helpers_unit
F:  6, 0: Unable to import 'gstswitch.helpers' (import-error)
F:  7, 0: Unable to import 'gstswitch.exception' (import-error)
F:  9, 0: Unable to import 'gstswitch' (import-error)
************* Module unittests.test_processmonitor_unit
F:  6, 0: Unable to import 'gstswitch.server' (import-error)
F:  8, 0: Unable to import 'gstswitch.exception' (import-error)
F:  9, 0: Unable to import 'gstswitch.exception' (import-error)
************* Module unittests.test_server_unit
F:  6, 0: Unable to import 'gstswitch.server' (import-error)
F:  8, 0: Unable to import 'gstswitch.exception' (import-error)
F:  9, 0: Unable to import 'gstswitch.exception' (import-error)
************* Module unittests.test_testsource_unit
F:  6, 0: Unable to import 'gstswitch.exception' (import-error)
F:  7, 0: Unable to import 'gstswitch.testsource' (import-error)
F:  8, 0: Unable to import 'gstswitch.testsource' (import-error)
make[1]: *** [lint] Error 1
make[1]: Leaving directory `/usr/local/google/home/tansell/foss/timvideos/gst-switch/gst-switch/python-api'
make: *** [test] Error 2
```