### PR TITLE
Don't use gcov symbols if coverage is disabled.

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -6,7 +6,7 @@ endif
 
 if GCOV_ENABLED
 # --coverage
-GCOV_CFLAGS = -fprofile-arcs -ftest-coverage
+GCOV_CFLAGS = -fprofile-arcs -ftest-coverage -DGCOV_ENABLED
 GCOV_LFLAGS = -fprofile-arcs -ftest-coverage
 #GCOV_CFLAGS = --coverage
 #GCOV_LFLAGS = --coverage

--- a/tools/gstswitchserver.c
+++ b/tools/gstswitchserver.c
@@ -1810,6 +1810,8 @@ error_prepare_recorder:
   }
 }
 
+#ifdef GCOV_ENABLED
+
 static unsigned long long i = 0;
 
 void
@@ -1821,11 +1823,14 @@ my_handler (int signum)
   __gcov_flush ();              /* dump coverage data on receiving SIGUSR1 */
 }
 
+#endif
+
 
 int
 main (int argc, char *argv[])
 {
 
+#ifdef GCOV_ENABLED
   struct sigaction new_action, old_action;
 
   /* setup signal hander */
@@ -1835,6 +1840,7 @@ main (int argc, char *argv[])
   sigaction (SIGUSR1, NULL, &old_action);
   if (old_action.sa_handler != SIG_IGN)
     sigaction (SIGUSR1, &new_action, NULL);
+#endif
 
   gint exit_code = 0;
   GstSwitchServer *srv;


### PR DESCRIPTION
Here is a patch for https://github.com/timvideos/gst-switch/issues/217 (build fails with coverage disabled)
