### PR TITLE
Publish the audio and video input ports via Avahi

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -7,6 +7,7 @@ sudo apt-get -y update && sudo apt-get -y upgrade
 sudo apt-get -y install build-essential dh-autoreconf
 sudo apt-get -y install libgtk-3-dev
 sudo apt-get -y install gstreamer1.0.* libgstreamer.*1.0.*
+sudo apt-get -y install libavahi-client-dev libavahi-glib-dev
 
 # Python stuff for gst-switch API - Python 2.7
 sudo apt-get -y install python-software-properties python-pip

--- a/build-min-trusty.sh
+++ b/build-min-trusty.sh
@@ -8,6 +8,8 @@ sudo apt-get install \
     libgstreamer-plugins-base1.0-dev \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-tools \
+    libavahi-client-dev \
+    libavahi-glib-dev \
     autoconf \
     libtool
 

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,13 @@ PKG_CHECK_MODULES(GDK, [
   ])
 ])
 
+dnl === Avahi =================================================================
+
+PKG_CHECK_MODULES(AVAHI, [
+  avahi-client
+  avahi-glib
+  ])
+
 dnl === gstreamer related options =============================================
 
 dnl Check for the required version of GStreamer core (and gst-plugins-base)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -24,11 +24,13 @@ endif
 gst_switch_srv_SOURCES = gstworker.c gstswitchserver.c gstcase.c \
   gstcomposite.c gstswitchcontroller.c gstrecorder.c \
   gio/gsocketinputstream.c gstswitchopts.c \
-  gstswitchcontrollerintrospection.c
+  gstswitchcontrollerintrospection.c \
+  gstswitchmdnspublish.c
 gst_switch_srv_CFLAGS = $(GST_CFLAGS) $(GST_BASE_CFLAGS) $(GCOV_CFLAGS) \
-  $(GST_PLUGINS_BASE_CFLAGS) $(AM_CFLAGS) -DLOG_PREFIX="\"gst-switch-srv\""
+  $(GST_PLUGINS_BASE_CFLAGS) $(AVAHI_CFLAGS) \
+  $(AM_CFLAGS) -DLOG_PREFIX="\"gst-switch-srv\""
 gst_switch_srv_LDFLAGS = $(GCOV_LFLAGS) $(GST_LIBS) $(GST_BASE_LIBS) \
-  $(GST_PLUGINS_BASE_LIBS) $(GSTPB_BASE_LIBS)
+  $(GST_PLUGINS_BASE_LIBS) $(GSTPB_BASE_LIBS) $(AVAHI_LIBS)
 gst_switch_srv_LDADD = $(GIO_LIBS) $(LIBM)
 
 gst_switch_ui_SOURCES = gstworker.c gstswitchui.c gstvideodisp.c \

--- a/tools/gstswitchmdnspublish.c
+++ b/tools/gstswitchmdnspublish.c
@@ -126,7 +126,7 @@ create_services (GstSwitchMdnsPublish *self)
    * Either way, add our entries */
   if (avahi_entry_group_is_empty (self->group)) {
     int error;
-    const char version_record[] = "version=1";
+    const char version_record[] = "txtvers=1";
     char *caps_record;
 
     /* Publish the video service */

--- a/tools/gstswitchmdnspublish.c
+++ b/tools/gstswitchmdnspublish.c
@@ -1,0 +1,221 @@
+/* gst-switch							    -*- c -*-
+ * Copyright (C) 2015 James Henstridge
+ *
+ * This file is part of gst-switch.
+ *
+ * gst-switch is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "gstswitchmdnspublish.h"
+#include "gstswitchserver.h"
+
+#include <avahi-common/alternative.h>
+#include <avahi-common/error.h>
+#include <avahi-glib/glib-malloc.h>
+
+G_DEFINE_TYPE (GstSwitchMdnsPublish, gst_switch_mdns_publish, G_TYPE_OBJECT);
+
+static void client_callback (AvahiClient *client, AvahiClientState state, void *user_data);
+static void group_callback (AvahiEntryGroup *group, AvahiEntryGroupState state, void *user_data);
+
+static void
+gst_switch_mdns_publish_finalize (GObject *object)
+{
+  GstSwitchMdnsPublish *self = GST_SWITCH_MDNS_PUBLISH (object);
+
+  if (self->group) {
+    avahi_entry_group_free (self->group);
+  }
+
+  g_free(self->service_name);
+
+  if (self->client) {
+    avahi_client_free (self->client);
+  }
+
+  if (self->poll) {
+    avahi_glib_poll_free (self->poll);
+  }
+
+  if (G_OBJECT_CLASS (gst_switch_mdns_publish_parent_class)->finalize)
+    G_OBJECT_CLASS (gst_switch_mdns_publish_parent_class)->finalize (object);
+}
+
+static void
+gst_switch_mdns_publish_class_init (GstSwitchMdnsPublishClass *class)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (class);
+  object_class->finalize = gst_switch_mdns_publish_finalize;
+}
+
+static void
+gst_switch_mdns_publish_init (GstSwitchMdnsPublish *self)
+{
+  avahi_set_allocator (avahi_glib_allocator ());
+
+  self->poll = avahi_glib_poll_new (NULL, G_PRIORITY_DEFAULT);
+  if (!self->poll) {
+    g_warning ("Could not create AvahiGLibPoll");
+    return;
+  }
+
+  int error = 0;
+  self->client = avahi_client_new (avahi_glib_poll_get (self->poll),
+                                   0,
+                                   client_callback,
+                                   self,
+                                   &error);
+  if (!self->client) {
+    g_warning ("Could not create Avahi client: %s", avahi_strerror(error));
+  }
+}
+
+GstSwitchMdnsPublish *
+gst_switch_mdns_publish_new (GstSwitchServerOpts *opts)
+{
+  GstSwitchMdnsPublish *self = g_object_new (GST_TYPE_SWITCH_MDNS_PUBLISH, NULL);
+  if (!self) {
+    return NULL;
+  }
+  return self;
+}
+
+static void
+create_services (GstSwitchMdnsPublish *self, AvahiClient *client)
+{
+  char *new_name = NULL;
+
+  if (!self->group) {
+    self->group = avahi_entry_group_new (client, group_callback, self);
+    if (!self->group) {
+      g_warning ("avahi_entry_group_new() failed: %s", avahi_strerror(avahi_client_errno(client)));
+      goto fail;
+    }
+  }
+
+  if (!self->service_name) {
+    // XXX: get this from options
+    self->service_name = g_strdup ("gst-switch");
+  }
+
+  /* The group will be empty if it was just created, or if we reset it
+   * due to a server name collision.
+   *
+   * Either way, add our entries */
+  if (avahi_entry_group_is_empty (self->group)) {
+    int error;
+
+    error = avahi_entry_group_add_service (
+      self->group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0,
+      self->service_name, "_gstswitch-video._tcp", NULL, NULL, opts.video_input_port,
+      NULL);
+    if (error == AVAHI_ERR_COLLISION) {
+      goto collision;
+    } else if (error != 0) {
+      g_warning ("Failed to add _gstswitch-video._tcp service: %s", avahi_strerror (error));
+      goto fail;
+    }
+
+    error = avahi_entry_group_add_service (
+      self->group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0,
+      self->service_name, "_gstswitch-audio._tcp", NULL, NULL, opts.audio_input_port,
+      NULL);
+    if (error == AVAHI_ERR_COLLISION) {
+      goto collision;
+    } else if (error != 0) {
+      g_warning ("Failed to add _gstswitch-audio._tcp service: %s", avahi_strerror (error));
+      goto fail;
+    }
+
+    error = avahi_entry_group_commit (self->group);
+    if (error != 0) {
+      g_warning ("Failed to commit entry group: %s", avahi_strerror (error));
+      goto fail;
+    }
+  }
+  return;
+
+collision:
+  new_name = avahi_alternative_service_name (self->service_name);
+  g_free(self->service_name);
+  self->service_name = new_name;
+
+  g_info ("Service name collision.  Renaming to %s", self->service_name);
+  avahi_entry_group_reset (self->group);
+  create_services (self, client);
+  return;
+
+fail:
+  if (self->group) {
+    avahi_entry_group_reset (self->group);
+  }
+}
+
+static void
+group_callback (AvahiEntryGroup *group, AvahiEntryGroupState state, void *user_data)
+{
+  GstSwitchMdnsPublish *self = user_data;
+  AvahiClient *client = avahi_entry_group_get_client (group);
+
+  switch (state) {
+  case AVAHI_ENTRY_GROUP_ESTABLISHED:
+    break;
+
+  case AVAHI_ENTRY_GROUP_COLLISION: {
+    char *new_name = avahi_alternative_service_name (self->service_name);
+    g_free(self->service_name);
+    self->service_name = new_name;
+
+    g_info ("Service name collision.  Renaming to %s", self->service_name);
+    avahi_entry_group_reset (group);
+    create_services (self, client);
+    break;
+  }
+
+  case AVAHI_ENTRY_GROUP_FAILURE:
+    g_warning ("Entry group failure: %s", avahi_strerror (avahi_client_errno (client)));
+    break;
+
+  case AVAHI_ENTRY_GROUP_UNCOMMITED:
+  case AVAHI_ENTRY_GROUP_REGISTERING:
+    break;
+  }
+}
+
+static void
+client_callback (AvahiClient *client, AvahiClientState state, void *user_data)
+{
+  GstSwitchMdnsPublish *self = user_data;
+
+  switch (state) {
+  case AVAHI_CLIENT_S_RUNNING:
+    create_services(self, client);
+    break;
+
+  case AVAHI_CLIENT_FAILURE:
+    g_warning("Avahi client failed: %s", avahi_strerror(avahi_client_errno(client)));
+    break;
+
+  case AVAHI_CLIENT_S_COLLISION:
+  case AVAHI_CLIENT_S_REGISTERING:
+    if (self->group) {
+      avahi_entry_group_reset (self->group);
+    }
+    break;
+
+  case AVAHI_CLIENT_CONNECTING:
+    break;
+  }
+}

--- a/tools/gstswitchmdnspublish.c
+++ b/tools/gstswitchmdnspublish.c
@@ -88,13 +88,17 @@ gst_switch_mdns_publish_init (GstSwitchMdnsPublish *self)
 }
 
 GstSwitchMdnsPublish *
-gst_switch_mdns_publish_new (GstSwitchServer *server)
+gst_switch_mdns_publish_new (GstSwitchServer *server, const char *service_name)
 {
+  g_return_if_fail(server != NULL);
+  g_return_if_fail(service_name != NULL);
+
   GstSwitchMdnsPublish *self = g_object_new (GST_TYPE_SWITCH_MDNS_PUBLISH, NULL);
   if (!self) {
     return NULL;
   }
 
+  self->service_name = g_strdup(service_name);
   self->server = g_object_ref (server);
   if (self->client && avahi_client_get_state (self->client) == AVAHI_CLIENT_S_RUNNING) {
     create_services (self);
@@ -113,11 +117,6 @@ create_services (GstSwitchMdnsPublish *self)
       g_warning ("avahi_entry_group_new() failed: %s", avahi_strerror(avahi_client_errno(self->client)));
       goto fail;
     }
-  }
-
-  if (!self->service_name) {
-    // XXX: get this from options
-    self->service_name = g_strdup ("gst-switch");
   }
 
   /* The group will be empty if it was just created, or if we reset it

--- a/tools/gstswitchmdnspublish.h
+++ b/tools/gstswitchmdnspublish.h
@@ -60,6 +60,7 @@ struct _GstSwitchMdnsPublishClass
 };
 
 GType gst_switch_mdns_publish_get_type (void);
-GstSwitchMdnsPublish *gst_switch_mdns_publish_new (GstSwitchServer *server);
+GstSwitchMdnsPublish *gst_switch_mdns_publish_new (GstSwitchServer *server,
+                                                   const char *service_name);
 
 #endif //__GST_SWITCH_MDNS_PUBLISH_H__

--- a/tools/gstswitchmdnspublish.h
+++ b/tools/gstswitchmdnspublish.h
@@ -22,6 +22,8 @@
 #ifndef __GST_SWITCH_MDNS_PUBLISH_H__
 #define __GST_SWITCH_MDNS_PUBLISH_H__
 
+#include "gstswitchserver.h"
+
 #include <glib-object.h>
 #include <avahi-client/client.h>
 #include <avahi-client/publish.h>
@@ -44,6 +46,8 @@ struct _GstSwitchMdnsPublish
   AvahiClient *client;
   char *service_name;
   AvahiEntryGroup *group;
+
+  GstSwitchServer *server;
 };
 
 /**
@@ -56,6 +60,6 @@ struct _GstSwitchMdnsPublishClass
 };
 
 GType gst_switch_mdns_publish_get_type (void);
-GstSwitchMdnsPublish *gst_switch_mdns_publish_new ();
+GstSwitchMdnsPublish *gst_switch_mdns_publish_new (GstSwitchServer *server);
 
 #endif //__GST_SWITCH_MDNS_PUBLISH_H__

--- a/tools/gstswitchmdnspublish.h
+++ b/tools/gstswitchmdnspublish.h
@@ -1,0 +1,61 @@
+/* gst-switch							    -*- c -*-
+ * Copyright (C) 2015 James Henstridge
+ *
+ * This file is part of gst-switch.
+ *
+ * gst-switch is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*! @file */
+
+#ifndef __GST_SWITCH_MDNS_PUBLISH_H__
+#define __GST_SWITCH_MDNS_PUBLISH_H__
+
+#include <glib-object.h>
+#include <avahi-client/client.h>
+#include <avahi-client/publish.h>
+#include <avahi-glib/glib-watch.h>
+
+#define GST_TYPE_SWITCH_MDNS_PUBLISH (gst_switch_mdns_publish_get_type())
+#define GST_SWITCH_MDNS_PUBLISH(object) (G_TYPE_CHECK_INSTANCE_CAST ((object), GST_TYPE_SWITCH_MDNS_PUBLISH, GstSwitchMdnsPublish))
+#define GST_SWITCH_MDNS_PUBLISH_CLASS(class) (G_TYPE_CHECK_CLASS_CAST ((class), GST_TYPE_SWITCH_MDNS_PUBLISH, GstSwitchMdnsPublishClass))
+#define GST_IS_SWITCH_MDNS_PUBLISH(object) (G_TYPE_CHECK_INSTANCE_TYPE ((object), GST_TYPE_SWITCH_MDNS_PUBLISH))
+#define GST_IS_SWITCH_MDNS_PUBLISH_CLASS(class) (G_TYPE_CHECK_CLASS_TYPE ((class), GST_TYPE_SWITCH_MDNS_PUBLISH))
+
+typedef struct _GstSwitchMdnsPublish GstSwitchMdnsPublish;
+typedef struct _GstSwitchMdnsPublishClass GstSwitchMdnsPublishClass;
+
+struct _GstSwitchMdnsPublish
+{
+  GObject base;
+
+  AvahiGLibPoll *poll;
+  AvahiClient *client;
+  char *service_name;
+  AvahiEntryGroup *group;
+};
+
+/**
+ *  GstSwitchMdnsPublishClass:
+ *  @param base_class the parent class
+ */
+struct _GstSwitchMdnsPublishClass
+{
+  GObjectClass base_class;
+};
+
+GType gst_switch_mdns_publish_get_type (void);
+GstSwitchMdnsPublish *gst_switch_mdns_publish_new ();
+
+#endif //__GST_SWITCH_MDNS_PUBLISH_H__

--- a/tools/gstswitchmdnspublish.h
+++ b/tools/gstswitchmdnspublish.h
@@ -60,7 +60,7 @@ struct _GstSwitchMdnsPublishClass
 };
 
 GType gst_switch_mdns_publish_get_type (void);
-GstSwitchMdnsPublish *gst_switch_mdns_publish_new (GstSwitchServer *server,
-                                                   const char *service_name);
+GstSwitchMdnsPublish *gst_switch_mdns_publish_new (GstSwitchServer * server,
+    const char *service_name);
 
 #endif //__GST_SWITCH_MDNS_PUBLISH_H__

--- a/tools/gstswitchserver.c
+++ b/tools/gstswitchserver.c
@@ -73,13 +73,17 @@
 G_DEFINE_TYPE (GstSwitchServer, gst_switch_server, G_TYPE_OBJECT);
 
 GstSwitchServerOpts opts = {
-  NULL, NULL,
-  GST_SWITCH_SERVER_DEFAULT_CONTROLLER_ADDRESS,
-  GST_SWITCH_SERVER_DEFAULT_VIDEO_ACCEPTOR_PORT,
-  GST_SWITCH_SERVER_DEFAULT_AUDIO_ACCEPTOR_PORT,
-//FALSE,
-  FALSE,
-  NULL, NULL
+  .test_switch        = NULL,
+  .record_filename    = NULL,
+  .controller_address = GST_SWITCH_SERVER_DEFAULT_CONTROLLER_ADDRESS,
+  .video_input_port   = GST_SWITCH_SERVER_DEFAULT_VIDEO_ACCEPTOR_PORT,
+  .audio_input_port   = GST_SWITCH_SERVER_DEFAULT_AUDIO_ACCEPTOR_PORT,
+//.verbose            = FALSE,
+  .low_res            = FALSE,
+  .video_caps         = NULL,
+  .video_caps_str     = NULL,
+  .audio_caps_str     = NULL,
+  .service_name       = "gst-switch",
 };
 
 gboolean verbose = FALSE;
@@ -226,6 +230,8 @@ static GOptionEntry entries[] = {
   {"controller-address", 'c', 0, G_OPTION_ARG_STRING, &opts.controller_address,
       "Specify DBus-Address for remote control, defaults to "
         GST_SWITCH_SERVER_DEFAULT_CONTROLLER_ADDRESS ".", "ADDRESS"},
+  {"service-name", 'n', 0, G_OPTION_ARG_STRING, &opts.service_name,
+      "Specify the zeroconf (Bonjour) service name", "NAME"},
   {NULL}
 };
 
@@ -1843,7 +1849,7 @@ main (int argc, char *argv[])
   gst_switch_server_parse_args (argc, argv);
 
   srv = GST_SWITCH_SERVER (g_object_new (GST_TYPE_SWITCH_SERVER, NULL));
-  publish = gst_switch_mdns_publish_new (srv);
+  publish = gst_switch_mdns_publish_new (srv, opts.service_name);
 
   gst_switch_server_run (srv);
 

--- a/tools/gstswitchserver.c
+++ b/tools/gstswitchserver.c
@@ -29,6 +29,7 @@
 #include "gstswitchserver.h"
 #include "gstrecorder.h"
 #include "gstcase.h"
+#include "gstswitchmdnspublish.h"
 #include "./gio/gsocketinputstream.h"
 #include "../logutils.h"
 
@@ -1838,12 +1839,15 @@ main (int argc, char *argv[])
 
   gint exit_code = 0;
   GstSwitchServer *srv;
+  GstSwitchMdnsPublish *publish;
   gst_switch_server_parse_args (argc, argv);
 
   srv = GST_SWITCH_SERVER (g_object_new (GST_TYPE_SWITCH_SERVER, NULL));
+  publish = gst_switch_mdns_publish_new ();
 
   gst_switch_server_run (srv);
 
+  g_object_unref (publish);
   exit_code = srv->exit_code;
   g_object_unref (srv);
 

--- a/tools/gstswitchserver.c
+++ b/tools/gstswitchserver.c
@@ -1843,7 +1843,7 @@ main (int argc, char *argv[])
   gst_switch_server_parse_args (argc, argv);
 
   srv = GST_SWITCH_SERVER (g_object_new (GST_TYPE_SWITCH_SERVER, NULL));
-  publish = gst_switch_mdns_publish_new ();
+  publish = gst_switch_mdns_publish_new (srv);
 
   gst_switch_server_run (srv);
 

--- a/tools/gstswitchserver.h
+++ b/tools/gstswitchserver.h
@@ -60,6 +60,7 @@ struct _GstSwitchServerOpts
   GstCaps *video_caps;
   gchar *video_caps_str;
   gchar *audio_caps_str;
+  gchar *service_name;
 };
 
 /**


### PR DESCRIPTION
I had a go at implementing https://github.com/timvideos/gst-switch/issues/194.  This branch adds the Avahi client libraries as a dependency, but the resulting binaries should still run if the Avahi service isn't running (it will just fail to publish the service).

It publishes two services of the types `_gstswitch-video._tcp` and `_gstswitch-audio._tcp` that match the two listening ports.  Each service has two TXT records attached:
- **txtvers** - a version number for the TXT metadata, in case it ever needs to be changed incompatibly.
- **caps** - the string version of the `GstCaps` expected for data sent to this port.

This should be enough for a smart capture client to notice when the server appears on the network, and what format data to send.  It could also automatically reconnect if the server changes IP address.

By default the server will use the name `gst-switch`, but this can be changed using the `--service-name` command line option.  If there are name conflicts, it will use Avahi's standard name conflict resolution method.

The code is based on the example from the Avahi documentation:

http://git.0pointer.net/avahi.git/tree/examples/client-publish-service.c

As an example, here is the `avahi-browse` output watching the audio service when I start and kill the server:

```
$ avahi-browse -r _gstswitch-audio._tcp
+   eth0 IPv6 gst-switch                                    _gstswitch-audio._tcp local
+   eth0 IPv4 gst-switch                                    _gstswitch-audio._tcp local
=   eth0 IPv6 gst-switch                                    _gstswitch-audio._tcp local
   hostname = [scruffy.local]
   address = [fe80::6ef0:49ff:feed:eadd]
   port = [4000]
   txt = ["caps=audio/x-raw, rate=48000, channels=2, format=S16LE, layout=interleaved" "txtvers=1"]
=   eth0 IPv4 gst-switch                                    _gstswitch-audio._tcp local
   hostname = [scruffy.local]
   address = [192.168.0.12]
   port = [4000]
   txt = ["caps=audio/x-raw, rate=48000, channels=2, format=S16LE, layout=interleaved" "txtvers=1"]
-   eth0 IPv6 gst-switch                                    _gstswitch-audio._tcp local
-   eth0 IPv4 gst-switch                                    _gstswitch-audio._tcp local
```
