### PR TITLE
Fix Travis test failures

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -1,7 +1,10 @@
 #! /bin/bash -ex
 
+export DEBIAN_FRONTEND=noninteractive
+
 # Update / upgrade everything
-sudo apt-get -y update && sudo apt-get -y upgrade
+sudo apt-get -y update
+sudo apt-get -o Dpkg::Options::="--force-confold" -y upgrade
 
 # gst-switch compile stuff
 sudo apt-get -y install build-essential dh-autoreconf

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -4,7 +4,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Update / upgrade everything
 sudo apt-get -y update
-sudo apt-get -o Dpkg::Options::="--force-confold" -y upgrade
 
 # gst-switch compile stuff
 sudo apt-get -y install build-essential dh-autoreconf
@@ -15,13 +14,13 @@ sudo apt-get -y install gstreamer1.0.* libgstreamer.*1.0.*
 sudo apt-get -y install python-software-properties python-pip
 sudo apt-get -y install libglib2.0-dev gir1.2-glib-2.0 libgirepository1.0-dev libglib2.0-0 python-gi
 sudo apt-get -y install python-scipy python-pil
-sudo pip install --upgrade -r requirements.txt subprocess32
+sudo pip install --upgrade --no-binary=pytest -r requirements.txt subprocess32
 
 # Python stuff for gst-switch API - Python 3.4
 sudo apt-get -y install python3-software-properties python3-pip
 sudo apt-get -y install libglib2.0-dev gir1.2-glib-2.0 libgirepository1.0-dev libglib2.0-0 python3-gi
 sudo apt-get -y install python3-scipy python3-pil
-sudo pip3 install --upgrade -r requirements.txt
+sudo pip3 install --upgrade --no-binary=pytest -r requirements.txt
 
 # Needed for tests
 sudo apt-get -y install wget libav-tools

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -4,6 +4,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Update / upgrade everything
 sudo apt-get -y update
+sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y upgrade
 
 # gst-switch compile stuff
 sudo apt-get -y install build-essential dh-autoreconf

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -20,7 +20,7 @@ sudo pip install --upgrade --no-binary=pytest -r requirements.txt subprocess32
 sudo apt-get -y install python3-software-properties python3-pip
 sudo apt-get -y install libglib2.0-dev gir1.2-glib-2.0 libgirepository1.0-dev libglib2.0-0 python3-gi
 sudo apt-get -y install python3-scipy python3-pil
-sudo pip3 install --upgrade --no-binary=pytest -r requirements.txt
+sudo pip3 install --upgrade -r requirements.txt
 
 # Needed for tests
 sudo apt-get -y install wget libav-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 #vim :
 sudo: required
+dist: trusty
 
 language:
  - c
@@ -19,15 +20,14 @@ env:
   - TEST=server TYPE=integration
 
 install:
- - wget -q -O- https://raw.githubusercontent.com/mithro/travis-trusty/master/setup.sh | bash
  - chmod a+rx $PWD/.travis-*.sh
- - /trusty/run.py $PWD/.travis-setup.sh
+ - $PWD/.travis-setup.sh
 
 script:
- - /trusty/run.py $PWD/.travis-run.sh
+ - $PWD/.travis-run.sh
 
 after_script:
- - /trusty/run.py $PWD/.travis-after.sh
+ - $PWD/.travis-after.sh
 
 notifications:
   email:

--- a/python-api/Makefile
+++ b/python-api/Makefile
@@ -3,9 +3,9 @@
 PYTHONVERSION := 3.4
 
 PYTEST := py.test-${PYTHONVERSION}
-PYLINT := python${PYTHONVERSION} $(shell which pylint)
+PYLINT := /usr/bin/python${PYTHONVERSION} $(shell which pylint)
 # Keep the --ignore in sync with setup.cfg
-PEP8 := python${PYTHONVERSION} $(shell which pep8) --ignore=E402
+PEP8 := /usr/bin/python${PYTHONVERSION} $(shell which pep8) --ignore=E402
 
 lint: export PYTHONWARNINGS := ignore
 lint: export PYTHONPATH := ${PYTHONPATH}:${PWD}

--- a/python-api/tests/unittests/test_connection_unit.py
+++ b/python-api/tests/unittests/test_connection_unit.py
@@ -180,7 +180,7 @@ class TestSignalSubscribe(object):
 
         # test that Gio's signal_subscribe method is called once
         # and passed the callback as-is
-        signal_subscribe_mock.assert_called_once()
+        assert signal_subscribe_mock.call_count == 1
 
         # pylint does not recognize Mock.call_args as sequence and won't
         # allow us to unpack it. Disabling the warning because we know what

--- a/python-api/tests/unittests/test_processmonitor_unit.py
+++ b/python-api/tests/unittests/test_processmonitor_unit.py
@@ -56,8 +56,8 @@ class TestProcessMonitor(object):
             mon.stdout = sys.stdout
             mon.terminate()
 
-            mocks['communicate'].assert_called_once()
-            mocks['terminate'].assert_called_once()
+            assert mocks['communicate'].call_count == 1
+            assert mocks['terminate'].call_count == 1
 
     def test_copy_remaining_on_terminate(self):
         """ Test if terminating a ProcessMonitor at least calls
@@ -113,7 +113,7 @@ class TestProcessMonitor(object):
             mon = ProcessMonitor('abc')
             mon._buffer = 'aaa ZZZ ccc'
             mon.wait_for_output('ZZZ', timeout=0, count=1)
-            mock.assert_called_once()
+            assert mock.call_count == 1
 
     def test_instant_fail(self):
         """ Test if wait_for_output fails instantly if the buffer
@@ -129,7 +129,7 @@ class TestProcessMonitor(object):
                 mon._buffer = 'aaa bbb ccc'
                 with pytest.raises(MatchTimeoutError):
                     mon.wait_for_output('ZZZ', timeout=0, count=1)
-                mock.assert_called_once()
+                assert mock.call_count == 1
 
     def test_instant_return_two_times(self):
         """ Test if wait_for_output returns instantly if the buffer
@@ -140,7 +140,7 @@ class TestProcessMonitor(object):
             mon = ProcessMonitor('abc')
             mon._buffer = 'aaa ZZZ ccc ZZZ ddd'
             mon.wait_for_output('ZZZ', timeout=0, count=2)
-            mock.assert_called_once()
+            assert mock.call_count == 1
 
     def test_instant_return_two_times_in_buffer(self):
         """ Test if wait_for_output returns instantly if the buffer
@@ -151,7 +151,7 @@ class TestProcessMonitor(object):
             mon = ProcessMonitor('abc')
             mon._buffer = 'aaa ZZZ ccc ZZZ ddd'
             mon.wait_for_output('ZZZ', timeout=0, count=1)
-            mock.assert_called_once()
+            assert mock.call_count == 1
 
     def test_instant_fail_two_times(self):
         """ Test if wait_for_output fails instantly if the buffer
@@ -166,7 +166,7 @@ class TestProcessMonitor(object):
                 mon._buffer = 'aaa ZZZ bbb ccc'
                 with pytest.raises(MatchTimeoutError):
                     mon.wait_for_output('ZZZ', timeout=0, count=2)
-            selectmock.assert_called_once()
+            assert selectmock.call_count == 1
 
     def test_fail_not_a_timeout(self):
         """ Test if wait_for_output fails if select.select returns without
@@ -180,7 +180,7 @@ class TestProcessMonitor(object):
                 mon._buffer = 'aaa bbb ccc'
                 with pytest.raises(SelectError):
                     mon.wait_for_output('ZZZ', timeout=500, count=1)
-                    mock.assert_called_once()
+                    assert mock.call_count == 1
 
     def test_read_returns_normally(self):
         """ Test if wait_for_output returns successfull with when os.read

--- a/python-api/tests/unittests/test_server_unit.py
+++ b/python-api/tests/unittests/test_server_unit.py
@@ -326,7 +326,7 @@ class TestRun(object):
         serv._start_process = Mock()
         serv.gst_option_string = '-ZZZ'
         serv._run_process()
-        serv._start_process.assert_called_once()
+        assert serv._start_process.call_count == 1
         assert '-ZZZ' in serv._start_process.call_args[0][0]
 
     def test_video_format(self):
@@ -335,7 +335,7 @@ class TestRun(object):
         serv._start_process = Mock()
         serv.video_format = 'ZZZ'
         serv._run_process()
-        serv._start_process.assert_called_once()
+        assert serv._start_process.call_count == 1
         assert '--video-format=ZZZ' in serv._start_process.call_args[0][0]
 
     def test_start_process_error(self, monkeypatch):


### PR DESCRIPTION
The test suite currently fails when run by Travis, likely due to changes in gst-switch's dependencies.  This branch corrects that.

It fixes broken assert_called_once() calls in the python-api test suite, and updates the CI build instructions to run directly on Travis's Trusty VM image rather than using a Trusty chroot on top of the Precise image.
